### PR TITLE
fix: dont create exchange when there is invalid pokemon

### DIFF
--- a/app/commands/create_exchange.rb
+++ b/app/commands/create_exchange.rb
@@ -1,14 +1,16 @@
 class CreateExchange
-  attr_reader :exchange, :left_side, :right_side
+  attr_reader :exchange, :left_side, :right_side, :find_pokemon
 
-  def initialize(params)
+  def initialize(params, **options)
     @left_side = params[:left]
     @right_side = params[:right]
+    @find_pokemon = options[:find_pokemon] || FindOrFetchPokemon
   end
 
   def call
-    @exchange = Exchange.create
+    @exchange = Exchange.new
     exchange_pokemons
+    exchange.save!
     exchange
   end
 
@@ -21,7 +23,7 @@ class CreateExchange
 
   def exchange_side(pokemon_names, side)
     pokemon_names.map do |pokemon_name|
-      pokemon = FindOrFetchPokemon.new(pokemon_name).call
+      pokemon = find_pokemon.new(pokemon_name).call
       ExchangedPokemon.create(pokemon: pokemon, side: side, exchange: exchange)
     end
   end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -8,17 +8,20 @@ class Exchange < ApplicationRecord
   end
 
   def left_pokemons
-    exchanged_pokemons.includes(:pokemon).select(&:left?)
+    pokemons_exchange_side(&:left?)
   end
 
   def right_pokemons
-    exchanged_pokemons.includes(:pokemon).select(&:right?)
+    pokemons_exchange_side(&:right?)
   end
 
   private
 
   def side_score(&block)
-    side_exchanged_pokemons = exchanged_pokemons.includes(:pokemon).select(&block)
-    side_exchanged_pokemons.sum(&:score)
+    pokemons_exchange_side(&block).sum(&:score)
+  end
+
+  def pokemons_exchange_side(&block)
+    exchanged_pokemons.includes(:pokemon).select(&block)
   end
 end

--- a/app/models/exchange.rb
+++ b/app/models/exchange.rb
@@ -1,5 +1,5 @@
 class Exchange < ApplicationRecord
-  has_many :exchanged_pokemons
+  has_many :exchanged_pokemons, dependent: :destroy
 
   scope :history, -> { order(created_at: :desc) }
 

--- a/spec/commands/create_exchange_spec.rb
+++ b/spec/commands/create_exchange_spec.rb
@@ -1,21 +1,50 @@
 require "rails_helper"
 
 RSpec.describe CreateExchange do
+  subject(:create_exchange) { CreateExchange.new(params, options).call }
+
   let(:bulbasaur) { create(:bulbasaur) }
   let(:charmander) { create(:charmander) }
   let(:squirtle) { create(:squirtle) }
   let(:params) { { left: [charmander.name, squirtle.name], right: [bulbasaur.name] } }
+  let(:options) { {} }
 
   it "creates three new pokemon exchanges" do
-    expect { CreateExchange.new(params).call }.to change(ExchangedPokemon, :count).by(3)
+    expect { create_exchange }.to change(ExchangedPokemon, :count).by(3)
   end
 
   it "creates a new exchanges" do
-    expect { CreateExchange.new(params).call }.to change(Exchange, :count).by(1)
+    expect { create_exchange }.to change(Exchange, :count).by(1)
   end
 
   it "expects to correctly save sides" do
-    exchange = CreateExchange.new(params).call
-    expect(exchange.exchanged_pokemons.map(&:side)).to eq(%w[left left right])
+    expect(create_exchange.exchanged_pokemons.map(&:side)).to eq(%w[left left right])
+  end
+
+  it "returns a Exchange instance" do
+    expect(create_exchange).to be_instance_of(Exchange)
+  end
+
+  context "when there is a unknown pokemon" do
+    let(:params) { { left: [charmander.name, squirtle.name], right: ["bulbasauro"] } }
+    let(:find_pokemon_instance) { double("FindPokemon instance") }
+    let(:find_pokemon_class) { double("FindPokemon Class", new: find_pokemon_instance) }
+    let(:options) { { find_pokemon: find_pokemon_class } }
+
+    before do
+      allow(find_pokemon_instance).to receive(:call).and_raise(FindOrFetchPokemon::PokemonNotFound)
+    end
+
+    it "expects to raise an error" do
+      expect { create_exchange }.to raise_error(FindOrFetchPokemon::PokemonNotFound)
+    end
+
+    it "expects not to create a exchange" do
+      expect do
+        create_exchange
+      rescue StandardError
+        nil
+      end.not_to change(Exchange, :count)
+    end
   end
 end


### PR DESCRIPTION
This PR fixes a bug that users were able to create empty exchanges.